### PR TITLE
Fix #5: OpenShift integration

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /back8sup.sh \
   && chmod +x /usr/local/bin/kubectl \
   && pip3 --no-cache-dir install yamllint yq \
   && mkdir -p /workdir \
-  && chgrp 0 /workdir \
+  && chgrp 0 -R /workdir \
   && chmod g=u -R /workdir
 
 WORKDIR /workdir

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,8 +10,13 @@ RUN chmod +x /back8sup.sh \
   && apk add --no-cache bash jq curl py3-pip \
   && curl -L -o/usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod +x /usr/local/bin/kubectl \
-  && pip3 --no-cache-dir install yamllint yq
+  && pip3 --no-cache-dir install yamllint yq \
+  && mkdir -p /workdir \
+  && chgrp 0 /workdir \
+  && chmod g=u -R /workdir
 
+WORKDIR /workdir
+ENV HOME /workdir
 USER 65534
 
 CMD ["/back8sup.sh"]


### PR DESCRIPTION
OpenShift uses a adapted permission model, where pods run as random high UIDs and GID=0. This prevents the kubectl API cache to be written to `~/.kube/cache`, as the user the pod is run as doesn't have write permissions to `~` aka `/`.

This PR resolves this issue by creating a new `/workdir` directory, which is set the proper permissions and is used as `WORKDIR` and `HOME`.