### PR TITLE
fix(bac8sup.sh): remove dir on top level

### DIFF
--- a/src/back8sup.sh
+++ b/src/back8sup.sh
@@ -151,4 +151,4 @@ done
 log "INFO done exporting namespace $NS"
 
 log "INFO keep last $GENERATIONS backups and delete the rest"
-ls -t -w 1 "$DST_FOLDER/*" | tail -n +$GENERATIONS | xargs rm -f
+ls -t -w 1 "$DST_FOLDER/" | tail -n +$GENERATIONS | xargs rm -rf


### PR DESCRIPTION
Removes directory on top level, rather then doing a `ls -t $DST_FOLDER/*`